### PR TITLE
VPN-6526: Add/restore "update required" strings for the VPN website

### DIFF
--- a/co/vpn.ftl
+++ b/co/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Cunnessione riesciuta.
 auth-success-return-to-app-button = Ritornu à { -vpn-product-name }
 auth-error-return-to-app = Ci vole à rivene à l’appiecazione { -vpn-product-name } è pruvà torna.
 auth-error-return-to-app-mobile = Ritornu à l’appiecazione { -vpn-product-name } per pruvà torna…
-auth-error-deprecated = Ci vole à <update>installà l’ultima versione</update> di { -vpn-product-name }.
+auth-error-update-required = Ci vole à installà l’ultima versione di { -vpn-product-name }.
 auth-error-unsupported-version = Scuperta d’una versione micca accettata.
 auth-error-unable-to-link = Umbè ! Un sbagliu hè accadutu.
 

--- a/cs/vpn.ftl
+++ b/cs/vpn.ftl
@@ -90,7 +90,7 @@ auth-success-linked-to-app = Přihlášení bylo úspěšné!
 auth-success-return-to-app-button = Vrátit se zpět do aplikace { -vpn-product-name }
 auth-error-return-to-app = Vraťte se prosím zpět do aplikace { -vpn-product-name } a zkuste to znovu.
 auth-error-return-to-app-mobile = Přesměrováváme vás zpět do aplikace { -vpn-product-name }, kde to můžete zkusit znovu…
-auth-error-deprecated = <update>Aktualizujte</update> prosím { -vpn-product-name(case: "acc") } na nejnovější verzi.
+auth-error-update-required = Aktualizujte prosím { -vpn-product-name(case: "acc") } na nejnovější verzi.
 auth-error-unsupported-version = Byla zjištěna nepodporovaná verze.
 auth-error-unable-to-link = Jejda. Něco je špatně.
 

--- a/cy/vpn.ftl
+++ b/cy/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Mewngofnodi'n llwyddiannus!
 auth-success-return-to-app-button = Ewch nôl i { -vpn-product-name }
 auth-error-return-to-app = Ewch nôl i'r ap { -vpn-product-name } i gwblhau'r gosod.
 auth-error-return-to-app-mobile = Ewch nôl i'r ap { -vpn-product-name } i geisio eto…
-auth-error-deprecated = <update>Diweddarwch</update> i'r fersiwn ddiweddaraf o { -vpn-product-name }.
+auth-error-update-required = Diweddarwch i'r fersiwn ddiweddaraf o { -vpn-product-name }.
 auth-error-unsupported-version = Fersiwn heb ei gefnogi wedi'i ganfod.
 auth-error-unable-to-link = Wps! Aeth rhywbeth o'i le.
 

--- a/de/vpn.ftl
+++ b/de/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Anmeldung erfolgreich!
 auth-success-return-to-app-button = Zurück zu { -vpn-product-name }
 auth-error-return-to-app = Bitte kehren Sie zur { -vpn-product-name }-App zurück und versuchen Sie es erneut.
 auth-error-return-to-app-mobile = Sie werden zur { -vpn-product-name }-App zurückgeleitet, um es erneut zu versuchen…
-auth-error-deprecated = Bitte <update>aktualisieren Sie</update> auf die neueste Version von { -vpn-product-name }.
+auth-error-update-required = Bitte aktualisieren Sie auf die neueste Version von { -vpn-product-name }.
 auth-error-unsupported-version = Nicht unterstützte Version erkannt.
 auth-error-unable-to-link = Hoppla, etwas ist schiefgegangen!
 

--- a/dsb/vpn.ftl
+++ b/dsb/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Pśizjawjenje jo było wuspěšne!
 auth-success-return-to-app-button = Slědk k { -vpn-product-name }
 auth-error-return-to-app = Pšosym wrośćo se k nałoženjeju { -vpn-product-name } a wopytajśo hyšći raz.
 auth-error-return-to-app-mobile = Wjedu was do nałoženja { -vpn-product-name } slědk a wopytajśo hyšći raz…
-auth-error-deprecated = Pšosym <update>aktualizěrujśo</update> na nejnowšu wersiju { -vpn-product-name }.
+auth-error-update-required = Pšosym aktualizěrujśo na nejnowšu wersiju { -vpn-product-name }.
 auth-error-unsupported-version = Njepódprěta wersija jo se namakała.
 auth-error-unable-to-link = Hopla! Něco njejo se raźiło.
 

--- a/el/vpn.ftl
+++ b/el/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Επιτυχής σύνδεση!
 auth-success-return-to-app-button = Επιστροφή στο { -vpn-product-name }
 auth-error-return-to-app = Παρακαλούμε επιστρέψτε στην εφαρμογή { -vpn-product-name } και δοκιμάστε ξανά.
 auth-error-return-to-app-mobile = Ανακατεύθυνση στην εφαρμογή { -vpn-product-name } για να δοκιμάσετε ξανά…
-auth-error-deprecated = Παρακαλούμε <update>ενημερώστε</update> στην πιο πρόσφατη έκδοση του { -vpn-product-name }.
+auth-error-update-required = Παρακαλούμε ενημερώστε στην πιο πρόσφατη έκδοση του { -vpn-product-name }.
 auth-error-unsupported-version = Εντοπίστηκε μη υποστηριζόμενη έκδοση.
 auth-error-unable-to-link = Ωχ! Κάτι πήγε στραβά.
 

--- a/en-CA/vpn.ftl
+++ b/en-CA/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Sign-in successful!
 auth-success-return-to-app-button = Return to { -vpn-product-name }
 auth-error-return-to-app = Please return to the { -vpn-product-name } app and try again.
 auth-error-return-to-app-mobile = Redirecting you back to the { -vpn-product-name } app to try again…
-auth-error-deprecated = Please <update>update</update> to the latest version of { -vpn-product-name }.
+auth-error-update-required = Please update to the latest version of { -vpn-product-name }.
 auth-error-unsupported-version = Unsupported version detected.
 auth-error-unable-to-link = Oops! Something went wrong.
 

--- a/en-GB/vpn.ftl
+++ b/en-GB/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Sign-in successful!
 auth-success-return-to-app-button = Return to { -vpn-product-name }
 auth-error-return-to-app = Please return to the { -vpn-product-name } app and try again.
 auth-error-return-to-app-mobile = Redirecting you back to the { -vpn-product-name } app to try again…
-auth-error-deprecated = Please <update>update</update> to the latest version of { -vpn-product-name }.
+auth-error-update-required = Please update to the latest version of { -vpn-product-name }.
 auth-error-unsupported-version = Unsupported version detected.
 auth-error-unable-to-link = Oops! Something went wrong.
 

--- a/en-US/vpn.ftl
+++ b/en-US/vpn.ftl
@@ -26,6 +26,8 @@ auth-page-title =
   .title = Please return to the { -vpn-product-name } app
 auth-error-return-to-app = Please return to the { -vpn-product-name } app and try again.
 auth-error-unable-to-link = Oops! Something went wrong.
+auth-error-unsupported-version = Unsupported version detected.
+auth-error-update-required = Please update to the latest version of { -vpn-product-name }.
 auth-success-return-to-app = Please return to the { -vpn-product-name } app to complete setup.
 auth-success-linked-to-app = Sign-in successful!
 

--- a/es-AR/vpn.ftl
+++ b/es-AR/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = ¡Inicio de sesión exitoso!
 auth-success-return-to-app-button = Volver a { -vpn-product-name }
 auth-error-return-to-app = Volver a la aplicación { -vpn-product-name } y volver a intentar.
 auth-error-return-to-app-mobile = Redirigiéndote a la aplicación { -vpn-product-name } para volver a intentarlo…
-auth-error-deprecated = <update>Actualizar </update> a la última versión de { -vpn-product-name }.
+auth-error-update-required = Actualizar a la última versión de { -vpn-product-name }.
 auth-error-unsupported-version = Se detectó una versión no compatible.
 auth-error-unable-to-link = Algo salió mal.
 

--- a/es-CL/vpn.ftl
+++ b/es-CL/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = ¡Conectado exitosamente!
 auth-success-return-to-app-button = Regresar a { -vpn-product-name }
 auth-error-return-to-app = Por favor, regresa a la app de { -vpn-product-name } y vuelve a intentarlo.
 auth-error-return-to-app-mobile = Redirigiéndote a la aplicación { -vpn-product-name } para volver a intentarlo…
-auth-error-deprecated = Por favor, <update>actualiza</update> a la última versión de { -vpn-product-name }.
+auth-error-update-required = Por favor, actualiza a la última versión de { -vpn-product-name }.
 auth-error-unsupported-version = Versión no soportada detectada.
 auth-error-unable-to-link = ¡Chuta! Algo se fue a las pailas.
 

--- a/es-ES/vpn.ftl
+++ b/es-ES/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = ¡Inicio de sesión correcto!
 auth-success-return-to-app-button = Volver a  { -vpn-product-name }
 auth-error-return-to-app = Volver a la aplicación { -vpn-product-name } y volver a intentar.
 auth-error-return-to-app-mobile = Redirigiéndote a la aplicación { -vpn-product-name } para volver a intentarlo…
-auth-error-deprecated = Por favor, <update>actualiza</update> a la última versión de { -vpn-product-name }.
+auth-error-update-required = Por favor, actualiza a la última versión de { -vpn-product-name }.
 auth-error-unsupported-version = Se ha detectado una versión no compatible.
 auth-error-unable-to-link = Se ha producido un error.
 

--- a/es-MX/vpn.ftl
+++ b/es-MX/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = ¡Inicio de sesión exitoso!
 auth-success-return-to-app-button = Regresar a { -vpn-product-name }
 auth-error-return-to-app = Por favor, regresa a la aplicación { -vpn-product-name } e intenta de nuevo.
 auth-error-return-to-app-mobile = Redirigiéndote a la aplicación { -vpn-product-name } para volver a intentarlo…
-auth-error-deprecated = Por favor, <update>actualiza</update> a la última versión de { -vpn-product-name }.
+auth-error-update-required = Por favor, actualiza a la última versión de { -vpn-product-name }.
 auth-error-unsupported-version = Se ha detectado una versión no compatible.
 auth-error-unable-to-link = ¡Ups! Algo salió mal.
 

--- a/fi/vpn.ftl
+++ b/fi/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Kirjautuminen onnistui!
 auth-success-return-to-app-button = Palaa { -vpn-product-name }:ään
 auth-error-return-to-app = Palaa { -vpn-product-name } -sovellukseen ja yritä uudestaan.
 auth-error-return-to-app-mobile = Ohjataan sinut takaisin { -vpn-product-name } -sovellukseen, yritä uudestaan…
-auth-error-deprecated = <update>Päivitä</update> uusimpaan { -vpn-product-name } -versioon.
+auth-error-update-required = Päivitä uusimpaan { -vpn-product-name } -versioon.
 auth-error-unsupported-version = Ei-tuettu versio havaittu.
 auth-error-unable-to-link = Oho! Jotain meni pieleen.
 

--- a/fr/vpn.ftl
+++ b/fr/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Connexion réussie !
 auth-success-return-to-app-button = Revenir sur { -vpn-product-name }
 auth-error-return-to-app = Veuillez retourner sur l’application { -vpn-product-name } et essayer à nouveau.
 auth-error-return-to-app-mobile = Nous vous redirigeons vers l’application { -vpn-product-name } pour que vous puissiez réessayer…
-auth-error-deprecated = Veuillez <update>mettre à jour</update> { -vpn-product-name } vers la dernière version.
+auth-error-update-required = Veuillez mettre à jour { -vpn-product-name } vers la dernière version.
 auth-error-unsupported-version = Version non prise en charge détectée.
 auth-error-unable-to-link = Oups, une erreur s’est produite.
 

--- a/fy-NL/vpn.ftl
+++ b/fy-NL/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Mei sukses oanmeld!
 auth-success-return-to-app-button = Werom nei { -vpn-product-name }
 auth-error-return-to-app = Gean werom nei de { -vpn-product-name }-app en probearje it opnij.
 auth-error-return-to-app-mobile = Jo wurde nei de { -vpn-product-name }-app weromstjoerd om it opnij te probearjen…
-auth-error-deprecated = <update>Fernij</update> nei de lêste ferzje fan { -vpn-product-name }.
+auth-error-update-required = Fernij nei de lêste ferzje fan { -vpn-product-name }.
 auth-error-unsupported-version = Net-stipe ferzje detektearre.
 auth-error-unable-to-link = Oeps, der is wat misgien.
 

--- a/hsb/vpn.ftl
+++ b/hsb/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Přizjewjenje bě wuspěšne!
 auth-success-return-to-app-button = Wróćo k { -vpn-product-name }
 auth-error-return-to-app = Prošu wróććo so k nałoženju { -vpn-product-name } a spytajće hišće raz.
 auth-error-return-to-app-mobile = Přiwjedu was do nałoženja { -vpn-product-name } wróćo, zo byšće hišće raz spytał…
-auth-error-deprecated = Prošu <update>aktualizujće</update> na najnowšu wersiju { -vpn-product-name }.
+auth-error-update-required = Prošu aktualizujće na najnowšu wersiju { -vpn-product-name }.
 auth-error-unsupported-version = Njepodpěrana wersija je so wotkryła.
 auth-error-unable-to-link = Hopla! Něšto je so nimokuliło.
 

--- a/hu/vpn.ftl
+++ b/hu/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Bejelentkezés sikeres!
 auth-success-return-to-app-button = Vissza a { -vpn-product-name }-hez
 auth-error-return-to-app = Térjen vissza a { -vpn-product-name } alkalmazáshoz, és próbálja újra.
 auth-error-return-to-app-mobile = Visszairányítás a { -vpn-product-name } alkalmazáshoz, hogy újrapróbálhassa…
-auth-error-deprecated = <update>Frissítsen</update> a { -vpn-product-name } legfrissebb verziójára.
+auth-error-update-required = Frissítsen a { -vpn-product-name } legfrissebb verziójára.
 auth-error-unsupported-version = Nem támogatott verzió észlelve.
 auth-error-unable-to-link = Hoppá, hiba történt.
 

--- a/ia/vpn.ftl
+++ b/ia/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Authentication con successo!
 auth-success-return-to-app-button = Retornar a { -vpn-product-name }
 auth-error-return-to-app = Retorna al app { -vpn-product-name } e reproba.
 auth-error-return-to-app-mobile = Redirigente te retro al app { -vpn-product-name } pro reprobar…
-auth-error-deprecated = <actualisar>Actualisa</actualisar> al ultime version de { -vpn-product-name }.
+auth-error-update-required = Actualisa al ultime version de { -vpn-product-name }.
 auth-error-unsupported-version = Version non supportate disvelate.
 auth-error-unable-to-link = Oppla! Alco errate eveniva.
 

--- a/it/vpn.ftl
+++ b/it/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Accesso riuscito.
 auth-success-return-to-app-button = Ritorna a { -vpn-product-name }
 auth-error-return-to-app = Torna all’app { -vpn-product-name } e riprova.
 auth-error-return-to-app-mobile = Reindirizzamento all’app { -vpn-product-name } per riprovare…
-auth-error-deprecated = <update>Aggiorna</update> { -vpn-product-name } all’ultima versione.
+auth-error-update-required = Aggiorna { -vpn-product-name } all’ultima versione.
 auth-error-unsupported-version = Rilevata versione non supportata.
 auth-error-unable-to-link = Oops, si è verificato un errore.
 

--- a/nl/vpn.ftl
+++ b/nl/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Met succes aangemeld!
 auth-success-return-to-app-button = Terug naar { -vpn-product-name }
 auth-error-return-to-app = Ga terug naar de { -vpn-product-name }-app en probeer het opnieuw.
 auth-error-return-to-app-mobile = U wordt naar de { -vpn-product-name }-app teruggestuurd om het opnieuw te proberen…
-auth-error-deprecated = <update>Werk bij</update> naar de nieuwste versie van { -vpn-product-name }.
+auth-error-update-required = Werk bij naar de nieuwste versie van { -vpn-product-name }.
 auth-error-unsupported-version = Niet-ondersteunde versie gedetecteerd.
 auth-error-unable-to-link = Oeps, er is iets misgegaan.
 

--- a/pa-IN/vpn.ftl
+++ b/pa-IN/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = ਕਾਮਯਾਬੀ ਨਾਲ ਸਾਈਨ ਇਨ
 auth-success-return-to-app-button = { -vpn-product-name } 'ਤੇ ਵਾਪਸ ਜਾਓ
 auth-error-return-to-app = { -vpn-product-name } ਉੱਤੇ ਵਾਪਸ ਜਾਓ ਤੇ ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰੋ।
 auth-error-return-to-app-mobile = ਫੇਰ ਕੋਸ਼ਿਸ਼ ਕਰਨ ਲਈ ਤੁਹਾਨੂੰ { -vpn-product-name } ਐਪ ਉੱਤੇ ਮੁੜ ਭੇਜਿਆ ਜਾ ਰਿਹਾ ਹੈ…
-auth-error-deprecated = { -vpn-product-name } ਦੇ ਨਵੇਂ ਵਰਜ਼ਨ ਲਈ <update>ਅੱਪਡੇਟ</update> ਕਰੋ।
+auth-error-update-required = { -vpn-product-name } ਦੇ ਨਵੇਂ ਵਰਜ਼ਨ ਲਈ ਅੱਪਡੇਟ ਕਰੋ।
 auth-error-unsupported-version = ਗ਼ੈਰ-ਸਹਾਇਕ ਵਰਜ਼ਨ ਮਿਲਿਆ ਹੈ।
 auth-error-unable-to-link = ਓਹ ਹੋ! ਕੁਝ ਗ਼ਲਤ ਵਾਪਰਿਆ ਹੈ।
 

--- a/pt-BR/vpn.ftl
+++ b/pt-BR/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Acesso bem-sucedido!
 auth-success-return-to-app-button = Voltar ao { -vpn-product-name }
 auth-error-return-to-app = Volte ao aplicativo { -vpn-product-name } e tente novamente.
 auth-error-return-to-app-mobile = Redirecionando você de volta ao aplicativo { -vpn-product-name } para tentar novamente…
-auth-error-deprecated = <update>Atualize</update> para a versão mais recente do { -vpn-product-name }.
+auth-error-update-required = Atualize para a versão mais recente do { -vpn-product-name }.
 auth-error-unsupported-version = Detectada versão não suportada.
 auth-error-unable-to-link = Ops, algo deu errado.
 

--- a/ru/vpn.ftl
+++ b/ru/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Вход выполнен успешно!
 auth-success-return-to-app-button = Вернуться в { -vpn-product-name }
 auth-error-return-to-app = Пожалуйста, вернитесь в приложение { -vpn-product-name } и попробуйте снова.
 auth-error-return-to-app-mobile = Перенаправляем вас обратно в приложение { -vpn-product-name }, чтобы повторить попытку…
-auth-error-deprecated = Пожалуйста, <update>обновите</update> { -vpn-product-name } до последней версии.
+auth-error-update-required = Пожалуйста, обновите { -vpn-product-name } до последней версии.
 auth-error-unsupported-version = Обнаружена неподдерживаемая версия.
 auth-error-unable-to-link = Ой! Что-то пошло не так.
 

--- a/sk/vpn.ftl
+++ b/sk/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Prihlásenie bolo úspešné!
 auth-success-return-to-app-button = Späť na { -vpn-product-name }
 auth-error-return-to-app = Prosím, vráťte sa do aplikácie { -vpn-product-name } a skúste to znova.
 auth-error-return-to-app-mobile = Presmerovávame vás späť do aplikácie { -vpn-product-name }, skúste to znova…
-auth-error-deprecated = Prosím, <update>aktualizujte</update> si { -vpn-product-name } na najnovšiu verziu.
+auth-error-update-required = Prosím, aktualizujte si { -vpn-product-name } na najnovšiu verziu.
 auth-error-unsupported-version = Bola zistená nepodporovaná verzia.
 auth-error-unable-to-link = Ups! Niečo sa pokazilo.
 

--- a/sq/vpn.ftl
+++ b/sq/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Hyrje e suksesshme!
 auth-success-return-to-app-button = Kthehu te { -vpn-product-name }
 auth-error-return-to-app = Ju lutemi, kthehuni te aplikacioni { -vpn-product-name } dhe riprovoni.
 auth-error-return-to-app-mobile = Po ju kthejmë mbrapsht te aplikacioni { -vpn-product-name }, që të riprovoni…
-auth-error-deprecated = Ju lutemi, <update>përditësojeni</update> me versionin më të ri të { -vpn-product-name }.
+auth-error-update-required = Ju lutemi, përditësojeni me versionin më të ri të { -vpn-product-name }.
 auth-error-unsupported-version = U pikas version i pambuluar.
 auth-error-unable-to-link = Oh! Diç shkoi ters.
 

--- a/sv-SE/vpn.ftl
+++ b/sv-SE/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Inloggningen lyckades!
 auth-success-return-to-app-button = Återgå till { -vpn-product-name }
 auth-error-return-to-app = Vänligen gå tillbaka till appen { -vpn-product-name } och försök igen.
 auth-error-return-to-app-mobile = Omdirigerar dig tillbaka till appen { -vpn-product-name } för att försöka igen...
-auth-error-deprecated = Vänligen <update>uppdatera</update> till den senaste versionen av { -vpn-product-name }.
+auth-error-update-required = Vänligen uppdatera till den senaste versionen av { -vpn-product-name }.
 auth-error-unsupported-version = Version som inte stöds upptäcktes.
 auth-error-unable-to-link = Hoppsan! Något gick fel.
 

--- a/uk/vpn.ftl
+++ b/uk/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = Ви успішно увійшли!
 auth-success-return-to-app-button = Повернутися до { -vpn-product-name }
 auth-error-return-to-app = Поверніться до програми { -vpn-product-name } і повторіть спробу.
 auth-error-return-to-app-mobile = Перенаправлення вас назад у програму { -vpn-product-name } для повторної спроби…
-auth-error-deprecated = <update>Оновіть<</update> { -vpn-product-name } до останньої версії.
+auth-error-update-required = Оновіть< { -vpn-product-name } до останньої версії.
 auth-error-unsupported-version = Виявлено непідтримувану версію.
 auth-error-unable-to-link = Халепа! Щось пішло не так.
 

--- a/zh-TW/vpn.ftl
+++ b/zh-TW/vpn.ftl
@@ -80,7 +80,7 @@ auth-success-linked-to-app = 登入成功！
 auth-success-return-to-app-button = 回到 { -vpn-product-name }
 auth-error-return-to-app = 請回到 { -vpn-product-name } 應用程式並再試一次。
 auth-error-return-to-app-mobile = 將您重導回 { -vpn-product-name } 應用程式重試…
-auth-error-deprecated = 請<update>更新</update>到最新版的 { -vpn-product-name }。
+auth-error-update-required = 請更新到最新版的 { -vpn-product-name }。
 auth-error-unsupported-version = 偵測到不支援的版本。
 auth-error-unable-to-link = 喔喔，有些東西不對勁！
 


### PR DESCRIPTION
## Description
We have a workstream to add a new frontend state to the guardian website that will inform users that their VPN client is too old to proceed with login, and that they are required to update their VPN client software in order to continue. There used to be some strings for this purpose (`auth-error-unsupported-version` and `auth-error-deprecated`).

This PR restores the `auth-error-unsupported-version` string that was removed in PR #5. No change is made to this string, we just want to use it as-is.

The text of the `auth-error-deprecated` string is just what we need, but unfortunately the translations include `<update>` tags for React that are no longer needed for the Guardian website. To address this, we create a new string, `auth-error-update-required`, and re-use the translations with the React tags stripped out. This has been done in a separate commit so that we can easily revert this translation re-use if we think it should be done a different way (eg: through Pontoon).

## Links
JIRA Issue: [VPN-6526](mozilla-hub.atlassian.net/browse/VPN-6526)
Guardian PR: https://github.com/mozilla-services/guardian-website/pull/1707