### PR TITLE
VPN-6526: Restore download-vpn-title string

### DIFF
--- a/co/vpn.ftl
+++ b/co/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Sbagliu
 page-not-found = A pagina ùn esiste micca.
 something-went-wrong = Ohimè, un sbagliu hè accadutu.
+download-vpn-title = Scaricà { -vpn-product-name }

--- a/cs/vpn.ftl
+++ b/cs/vpn.ftl
@@ -50,3 +50,4 @@ vpn-error-page-title =
 error = Chyba
 page-not-found = Stránka nenalezena.
 something-went-wrong = Jejda, něco je špatně.
+download-vpn-title = Stáhnout { -vpn-product-name(case: "acc") }

--- a/cy/vpn.ftl
+++ b/cy/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Gwall
 page-not-found = Heb ganfod y dudalen
 something-went-wrong = Wps! Aeth rhywbeth o'i le.
+download-vpn-title = Llwytho { -vpn-product-name } i Lawr

--- a/de/vpn.ftl
+++ b/de/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Fehler
 page-not-found = Seite nicht gefunden.
 something-went-wrong = Hoppla, etwas ist schiefgegangen.
+download-vpn-title = { -vpn-product-name } herunterladen

--- a/dsb/vpn.ftl
+++ b/dsb/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Zmólka
 page-not-found = Bok njejo se namakał.
 something-went-wrong = Hopla, něco njejo se raźiło.
+download-vpn-title = { -vpn-product-name } ześěgnuś

--- a/el/vpn.ftl
+++ b/el/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Σφάλμα
 page-not-found = Η σελίδα δεν βρέθηκε.
 something-went-wrong = Ωχ, κάτι πήγε στραβά.
+download-vpn-title = Λήψη του { -vpn-product-name }

--- a/en-CA/vpn.ftl
+++ b/en-CA/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = Page not found.
 something-went-wrong = Oops, something went wrong.
+download-vpn-title = Download { -vpn-product-name }

--- a/en-GB/vpn.ftl
+++ b/en-GB/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = Page not found.
 something-went-wrong = Oops, something went wrong.
+download-vpn-title = Download { -vpn-product-name }

--- a/en-US/vpn.ftl
+++ b/en-US/vpn.ftl
@@ -39,3 +39,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = Page not found.
 something-went-wrong = Oops, something went wrong.
+download-vpn-title = Download { -vpn-product-name }

--- a/es-AR/vpn.ftl
+++ b/es-AR/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = No se encontró la página
 something-went-wrong = Algo salió mal.
+download-vpn-title = Descargar { -vpn-product-name }

--- a/es-CL/vpn.ftl
+++ b/es-CL/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = Página no encontrada.
 something-went-wrong = Chuta, algo se fue a las pailas.
+download-vpn-title = Descargar { -vpn-product-name }

--- a/es-ES/vpn.ftl
+++ b/es-ES/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = Página no encontrada.
 something-went-wrong = Se ha producido un error.
+download-vpn-title = Descargar { -vpn-product-name }

--- a/es-MX/vpn.ftl
+++ b/es-MX/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = Página no encontrada.
 something-went-wrong = Ups, algo salió mal.
+download-vpn-title = Descargar { -vpn-product-name }

--- a/fi/vpn.ftl
+++ b/fi/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Virhe
 page-not-found = Sivua ei löydy.
 something-went-wrong = Jokin meni pieleen.
+download-vpn-title = Lataa { -vpn-product-name }

--- a/fr/vpn.ftl
+++ b/fr/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Erreur
 page-not-found = Page introuvable.
 something-went-wrong = Oups, une erreur s’est produite.
+download-vpn-title = Télécharger { -vpn-product-name }

--- a/fy-NL/vpn.ftl
+++ b/fy-NL/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Flater
 page-not-found = Side net fûn.
 something-went-wrong = Oeps, der is wat misgien.
+download-vpn-title = { -vpn-product-name } downloade

--- a/hsb/vpn.ftl
+++ b/hsb/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Zmylk
 page-not-found = Strona njeje so namakała.
 something-went-wrong = Hopla, něšto je so nimokuliło.
+download-vpn-title = { -vpn-product-name } sćahnyć

--- a/hu/vpn.ftl
+++ b/hu/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Hiba
 page-not-found = Az oldal nem található.
 something-went-wrong = Hoppá, hiba történt.
+download-vpn-title = { -vpn-product-name } letöltése

--- a/ia/vpn.ftl
+++ b/ia/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Error
 page-not-found = Pagina non trovate.
 something-went-wrong = Oppla! Alco errate eveniva.
+download-vpn-title = Discargar { -vpn-product-name }

--- a/id/vpn.ftl
+++ b/id/vpn.ftl
@@ -38,3 +38,4 @@ vpn-error-page-title =
 error = Masalah
 page-not-found = Laman tidak ditemukan.
 something-went-wrong = Ups, terjadi kesalahan
+download-vpn-title = Unduh { -vpn-product-name }

--- a/it/vpn.ftl
+++ b/it/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Errore
 page-not-found = Pagina non trovata.
 something-went-wrong = Oops, si è verificato un errore.
+download-vpn-title = Scarica { -vpn-product-name }

--- a/nl/vpn.ftl
+++ b/nl/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Fout
 page-not-found = Pagina niet gevonden.
 something-went-wrong = Oeps, er is iets misgegaan.
+download-vpn-title = { -vpn-product-name } downloaden

--- a/pa-IN/vpn.ftl
+++ b/pa-IN/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = ਗਲਤੀ
 page-not-found = ਸਫਾ ਨਹੀਂ ਲੱਭਿਆ।
 something-went-wrong = ਓਹ ਹੋ, ਕੁਝ ਗ਼ਲਤ ਵਾਪਰਿਆ ਹੈ।
+download-vpn-title = { -vpn-product-name } ਨੂੰ ਡਾਉਨਲੋਡ ਕਰੋ

--- a/pt-BR/vpn.ftl
+++ b/pt-BR/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Erro
 page-not-found = Página não encontrada.
 something-went-wrong = Ops, algo deu errado.
+download-vpn-title = Baixar o { -vpn-product-name }

--- a/ru/vpn.ftl
+++ b/ru/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Ошибка
 page-not-found = Страница не найдена.
 something-went-wrong = Ой, что-то пошло не так.
+download-vpn-title = Загрузить { -vpn-product-name }

--- a/sk/vpn.ftl
+++ b/sk/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Chyba
 page-not-found = Stránka nebola nájdená.
 something-went-wrong = Ups, niečo sa pokazilo.
+download-vpn-title = Stiahnuť { -vpn-product-name }

--- a/sq/vpn.ftl
+++ b/sq/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Gabim
 page-not-found = S’u gjet faqe.
 something-went-wrong = Oh, diç shkoi ters.
+download-vpn-title = Shkarkoni { -vpn-product-name }

--- a/sv-SE/vpn.ftl
+++ b/sv-SE/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Fel
 page-not-found = Sidan hittades inte.
 something-went-wrong = Hoppsan, något gick fel.
+download-vpn-title = Hämta { -vpn-product-name }

--- a/uk/vpn.ftl
+++ b/uk/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = Помилка
 page-not-found = Сторінку не знайдено.
 something-went-wrong = Отакої, щось пішло не так!
+download-vpn-title = Завантажити { -vpn-product-name }

--- a/zh-TW/vpn.ftl
+++ b/zh-TW/vpn.ftl
@@ -40,3 +40,4 @@ vpn-error-page-title =
 error = 錯誤
 page-not-found = 找不到頁面。
 something-went-wrong = 喔喔，有些東西不對勁！
+download-vpn-title = 下載 { -vpn-product-name }


### PR DESCRIPTION
Description
-----------
Over on the guardian website, we are trying to add a new frontend to inform users that they need to update their client before proceeding. This required the addition of a couple strings, which I tried to add in PR #7. Unfortunately, I forgot one! We had a string in the old guardian page `download-vpn-title` which we had been reusing for the text of the download link. These strings got removed in 05f15bb1c27eebc5dae5640eaa5885023d2f50e2, so we'll need to put those back.

Links
-----
JIRA Issue: [VPN-6526](https://mozilla-hub.atlassian.net/browse/VPN-6526)
Guardian PR: mozilla-services/guardian-website#1707